### PR TITLE
Update setup.py to fix No module named 'posepile.util' Error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version='0.1.0',
     author='István Sárándi',
     author_email='sarandi@vision.rwth-aachen.de',
-    packages=['posepile'],
+    packages=['posepile','posepile.util'],
     scripts=[],
     license='LICENSE',
     description='',
@@ -34,5 +34,6 @@ setup(
         'simplepyutils @ git+https://github.com/isarandi/simplepyutils.git',
         'humcentr-cli @ git+https://github.com/isarandi/humcentr-cli.git',
         'barecat @ git+https://github.com/isarandi/BareCat.git',
+        'posepile.util @ git+https://github.com/isarandi/PosePile.git'
     ]
 )


### PR DESCRIPTION
I encountered the same issue as referenced [here](https://github.com/isarandi/PosePile/issues/2#issue-1842347976), and created a patch that should at least allow the command mentioned in [MeTRAbs](https://github.com/isarandi/metrabs) to install the experimental pytorch model.