### PR TITLE
fix: pin rlemasklib in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'multiprocessing-utils',
         'cameralib @ git+https://github.com/isarandi/cameralib.git',
         'boxlib @ git+https://github.com/isarandi/boxlib.git',
-        'rlemasklib @ git+https://github.com/isarandi/rlemasklib.git',
+        'rlemasklib @ https://github.com/isarandi/rlemasklib/archive/c9774716c9943459d8beb8cf3b3b4d5b9fe4169c.zip',
         'simplepyutils @ git+https://github.com/isarandi/simplepyutils.git',
     ]
 )


### PR DESCRIPTION
The rlemasklib library has recently started receiving updates, which has led to frequent installation issues.
To ensure compatibility and stability when using posepile, this MR pins rlemasklib to a previously verified version.